### PR TITLE
Return when nothing passed to getAbsolutelUrl

### DIFF
--- a/extension/unpaywall.js
+++ b/extension/unpaywall.js
@@ -706,6 +706,7 @@ var getAbsoluteUrl = (function() {
 	var a;
 
 	return function(url) {
+		if(!url) return;
 		if(!a) a = document.createElement('a');
 		a.href = url;
 


### PR DESCRIPTION
Prevents unnecessary xhr requests to /undefined when fishing for PDF files.